### PR TITLE
Remove parallel streaming

### DIFF
--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -69,7 +69,7 @@ public class ProfitTrackerInventoryValue {
 
         Item[] items = container.getItems();
 
-        newInventoryValue = Arrays.stream(items).parallel().flatMapToLong(item ->
+        newInventoryValue = Arrays.stream(items).flatMapToLong(item ->
                 LongStream.of(calculateItemValue(item))
         ).sum();
 


### PR DESCRIPTION
Parallel streams are run on a seperate thread causing AssertionError: must be run on client thread when calling ItemManager.getItemPrice