### PR TITLE
Remove deprecated API references

### DIFF
--- a/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
+++ b/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
@@ -235,7 +235,7 @@ public class ProfitTrackerGoldDrops {
     {
         // taken from XpDropPlugin
         EnumComposition colorEnum = client.getEnum(EnumID.XPDROP_COLORS);
-        int defaultColorId = client.getVar(Varbits.EXPERIENCE_DROP_COLOR);
+        int defaultColorId = client.getVarbitValue(Varbits.EXPERIENCE_DROP_COLOR);
         int color = colorEnum.getIntValue(defaultColorId);
         xpDropTextWidget.setTextColor(color);
     }

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -223,8 +223,8 @@ public class ProfitTrackerPlugin extends Plugin
     @Subscribe
     public void onMenuOptionClicked(MenuOptionClicked event) {
         /* for ignoring deposit in deposit box */
-        log.info(String.format("Click! ID: %d, actionParam: %d ,menuOption: %s, menuTarget: %s, widgetId: %d",
-                event.getId(), event.getActionParam(), event.getMenuOption(), event.getMenuTarget(), event.getWidgetId()));
+        log.info(String.format("Click! ID: %d ,menuOption: %s, menuTarget: %s",
+                event.getId(), event.getMenuOption(), event.getMenuTarget()));
 
         if (event.getId() == ObjectID.BANK_DEPOSIT_BOX) {
             // we've interacted with a deposit box. Don't take this tick into account for profit calculation


### PR DESCRIPTION
Replaces `.getVar` with `.getVarbitValue`.

Also removed obsolete calls to `.getActionParam()` and `.getWidgetId()`. From what I can tell, there is no replacements. But these were just used in a log file, so I just removed them.