### PR TITLE
Add Xlint checks to build.gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,4 +31,6 @@ sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.compilerArgs << "-Xlint:unchecked"
+	options.compilerArgs << "-Xlint:deprecation"
 }


### PR DESCRIPTION
These help catch some warnings that are critical issues for runelite (e.g. deprecated API calls, unchecked issues, etc.)